### PR TITLE
Fix NextAuth build issue

### DIFF
--- a/app/api/auth/[...nextauth]/route.ts
+++ b/app/api/auth/[...nextauth]/route.ts
@@ -1,15 +1,5 @@
 import NextAuth from "next-auth";
-import GitHubProvider from "next-auth/providers/github";
-
-export const authOptions = {
-  providers: [
-    GitHubProvider({
-      clientId: process.env.GITHUB_ID!,
-      clientSecret: process.env.GITHUB_SECRET!,
-    }),
-  ],
-  secret: process.env.NEXTAUTH_SECRET,
-};
+import { authOptions } from "@/lib/auth";
 
 const handler = NextAuth(authOptions);
 export { handler as GET, handler as POST };

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,5 +1,5 @@
 import { getServerSession } from "next-auth";
-import { authOptions } from "./api/auth/[...nextauth]/route";
+import { authOptions } from "@/lib/auth";
 import Link from "next/link";
 
 export default async function Page() {

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -1,0 +1,12 @@
+import type { NextAuthOptions } from "next-auth";
+import GitHubProvider from "next-auth/providers/github";
+
+export const authOptions: NextAuthOptions = {
+  providers: [
+    GitHubProvider({
+      clientId: process.env.GITHUB_ID!,
+      clientSecret: process.env.GITHUB_SECRET!,
+    }),
+  ],
+  secret: process.env.NEXTAUTH_SECRET,
+};


### PR DESCRIPTION
## Summary
- move `authOptions` to new `lib/auth` module
- update API route to import options from `lib`
- update page to use new auth import

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6878954c42108327bc937d6ba12e01bf